### PR TITLE
Authorize owner only when minting or setting base uri.

### DIFF
--- a/logics/Cargo.toml
+++ b/logics/Cargo.toml
@@ -16,7 +16,7 @@ ink_prelude = { version = "4.3.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 logion_contract = { tag = "v0.1.2", git = "https://github.com/logion-network/logion-ink", default-features = false }
-openbrush = { tag = "4.0.0", git = "https://github.com/Brushfam/openbrush-contracts", default-features = false, features = ["psp34"] }
+openbrush = { tag = "4.0.0", git = "https://github.com/Brushfam/openbrush-contracts", default-features = false, features = ["psp34", "ownable"] }
 
 [lib]
 path = "lib.rs"

--- a/logics/impls/psp34_traits.rs
+++ b/logics/impls/psp34_traits.rs
@@ -5,18 +5,21 @@ use ink::prelude::{
     },
 };
 use openbrush::{
+    contracts::ownable::*,
     contracts::psp34::extensions::{
         metadata::{Internal, PSP34Impl, PSP34MetadataImpl},
     },
+    modifiers,
+    traits::Storage,
 };
-
 use crate::traits::error::Error;
 
 #[openbrush::trait_definition]
-pub trait Psp34Traits: PSP34Impl + PSP34MetadataImpl + Internal {
+pub trait Psp34Traits: PSP34Impl + PSP34MetadataImpl + Internal + Storage<ownable::Data> {
 
     /// Change baseURI
     #[ink(message)]
+    #[modifiers(only_owner)]
     fn set_base_uri(&mut self, uri: String) -> Result<(), Error> {
         let collection_id = PSP34Impl::collection_id(self);
         self._set_attribute(collection_id, String::from("baseURI"), uri);

--- a/logics/traits/error.rs
+++ b/logics/traits/error.rs
@@ -1,5 +1,14 @@
 
+use openbrush::contracts::ownable::OwnableError;
+
 #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub enum Error {
+    OwnableError(OwnableError),
+}
+
+impl From<OwnableError> for Error {
+    fn from(ownable: OwnableError) -> Self {
+        Error::OwnableError(ownable)
+    }
 }

--- a/logics/traits/psp34_traits.rs
+++ b/logics/traits/psp34_traits.rs
@@ -1,5 +1,6 @@
 use openbrush::traits::String;
 use crate::traits::error::Error;
+use openbrush::modifiers;
 
 #[openbrush::wrapper]
 pub type Psp34TraitsContractRef = dyn Psp34TraitsContract;
@@ -8,6 +9,7 @@ pub type Psp34TraitsContractRef = dyn Psp34TraitsContract;
 pub trait Psp34TraitsContract {
     /// This function sets the baseURI for the NFT contract. Only Contract Owner can perform this function. baseURI is the location of the metadata files if the NFT collection use external source to keep their NFT artwork. ArtZero uses IPFS by default, the baseURI can have format like this: ipfs://<hash_ID>/
     #[ink(message)]
+    #[modifiers(only_owner)]
     fn set_base_uri(&mut self, uri: String) -> Result<(), Error>;
     /// This function return the metadata location of an NFT. The format is baseURI/<token_id>.json
     #[ink(message)]


### PR DESCRIPTION
Sensitive operations (i.e. `mint` and `set_base_uri`) are now reserved to contract owner.

logion-network/logion-internal#1013