### PR TITLE
Mint to many accounts

### DIFF
--- a/contracts/art_nft_psp34/lib.rs
+++ b/contracts/art_nft_psp34/lib.rs
@@ -42,7 +42,12 @@ pub mod art_nft_psp34 {
             }
         }
 
-        /// Mint one NFT for each given account, using TokenID U64(0..n)
+        #[doc = "Mint one NFT for each given account. \n"]
+        #[doc = "If t is the total supply at call time, for given accounts[0..n],\n"]
+        #[doc = "NFT with id U64(t + 0) is minted to accounts[0],\n"]
+        #[doc = "NFT with id U64(t + 1) is minted to accounts[1],\n"]
+        #[doc = "...\n"]
+        #[doc = "NFT with id U64(t + n) is minted to accounts[n].\n"]
         #[ink(message)]
         #[modifiers(only_owner)]
         pub fn mint(&mut self, accounts: Vec<AccountId>) -> Result<Vec<(AccountId, Id)>, PSP34Error> {

--- a/contracts/art_nft_psp34/lib.rs
+++ b/contracts/art_nft_psp34/lib.rs
@@ -1,15 +1,15 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
-#[openbrush::implementation(PSP34, PSP34Mintable, PSP34Metadata, PSP34Enumerable, Ownable)]
+#[openbrush::implementation(PSP34, PSP34Metadata, PSP34Enumerable, Ownable)]
 #[openbrush::contract]
 pub mod art_nft_psp34 {
     use logion_contract::impls::logion::*;
     use logion_contract::impls::types as logion;
-    use psp34_traits::impls::psp34_traits::*;
+    use openbrush::contracts::ownable::*;
+    use openbrush::modifiers;
     use openbrush::traits::Storage;
     use openbrush::traits::String;
-    use openbrush::modifiers;
-    use openbrush::contracts::ownable::*;
+    use psp34_traits::impls::psp34_traits::*;
 
     #[ink(storage)]
     #[derive(Default, Storage)]
@@ -26,18 +26,11 @@ pub mod art_nft_psp34 {
         logion: logion::Data,
     }
 
-
-    #[overrider(PSP34Mintable)]
-    #[modifiers(only_owner)]
-    fn mint(&mut self, account: AccountId, id: Id) -> Result<(), PSP34Error> {
-        psp34::InternalImpl::_mint_to(self, account, id)
-    }
-
     impl Logion for ArtNft {}
+
     impl Psp34Traits for ArtNft {}
 
     impl ArtNft {
-
         #[ink(constructor)]
         pub fn new(nonce: String, collection_loc_id: u128, cert_host: String) -> Self {
             let mut instance = Self::default();
@@ -48,19 +41,35 @@ pub mod art_nft_psp34 {
                 _ => panic!("Failed to set default base_uri")
             }
         }
+
+        /// Mint one NFT for each given account, using TokenID U64(0..n)
+        #[ink(message)]
+        #[modifiers(only_owner)]
+        pub fn mint(&mut self, accounts: Vec<AccountId>) -> Result<Vec<(AccountId, Id)>, PSP34Error> {
+            let total_supply_after_mint = u64::try_from(PSP34::total_supply(self) + (accounts.len() as u128));
+            if total_supply_after_mint.is_err() {
+                Err(PSP34Error::Custom(String::from("About to mint too much NFTs, total supply must remain less than u64::MAX")))?
+            }
+            let mut next_token_index: u64 = PSP34::total_supply(self) as u64;
+            let mut token_ids = Vec::new();
+            for account in &accounts {
+                let token_id = Id::U64(next_token_index);
+                psp34::InternalImpl::_mint_to(self, *account, token_id.clone())?;
+                next_token_index += 1;
+                token_ids.push((*account, token_id));
+            };
+            Ok(token_ids)
+        }
     }
 
     #[cfg(test)]
     mod tests {
+        use ink::env::test;
+        use psp34_traits::traits::error::Error;
+
+        use crate::art_nft_psp34::{PSP34, PSP34Error};
 
         use super::*;
-        use ink::{
-            env::{
-                test,
-            },
-        };
-        use psp34_traits::traits::error::Error;
-        use crate::art_nft_psp34::{ PSP34Mintable, PSP34, PSP34Error };
 
         const COLLECTION_LOC_ID: u128 = 334801581596596632473758891935041239976;
 
@@ -88,11 +97,30 @@ pub mod art_nft_psp34 {
         }
 
         #[ink::test]
-        fn it_mints() {
+        fn it_mints_for_one_account() {
             let mut contract = new_contract();
             let accounts = default_accounts();
-            let result = PSP34Mintable::mint(&mut contract, accounts.bob, Id::U64(0));
-            assert_eq!(result, Ok(()));
+            let result = ArtNft::mint(&mut contract, vec![accounts.bob]);
+            assert_eq!(result, Ok(vec![(accounts.bob, Id::U64(0))]));
+            assert_eq!(PSP34::owner_of(&contract, Id::U64(0)), Some(accounts.bob));
+            assert_eq!(PSP34Enumerable::owners_token_by_index(&contract, accounts.bob, 0), Ok(Id::U64(0)));
+            assert_eq!(PSP34::balance_of(&contract, accounts.bob), 1);
+        }
+
+        #[ink::test]
+        fn it_mints_for_many_accounts() {
+            let mut contract = new_contract();
+            let accounts = default_accounts();
+            let result = ArtNft::mint(&mut contract, vec![
+                accounts.bob,
+                accounts.alice,
+                accounts.charlie,
+            ]);
+            assert_eq!(result, Ok(vec![
+                (accounts.bob, Id::U64(0)),
+                (accounts.alice, Id::U64(1)),
+                (accounts.charlie, Id::U64(2)),
+            ]));
             assert_eq!(PSP34::owner_of(&contract, Id::U64(0)), Some(accounts.bob));
             assert_eq!(PSP34Enumerable::owners_token_by_index(&contract, accounts.bob, 0), Ok(Id::U64(0)));
             assert_eq!(PSP34::balance_of(&contract, accounts.bob), 1);
@@ -103,9 +131,9 @@ pub mod art_nft_psp34 {
             let mut contract = new_contract();
             let accounts = default_accounts();
             set_sender(accounts.bob);
-            let result = PSP34Mintable::mint(&mut contract, accounts.bob, Id::U64(1));
+            let result = ArtNft::mint(&mut contract, vec![accounts.bob]);
             assert_eq!(result, Err(PSP34Error::Custom("O::CallerIsNotOwner".to_string())));
-            assert_eq!(PSP34::owner_of(&contract, Id::U64(1)), None);
+            assert_eq!(PSP34::owner_of(&contract, Id::U64(0)), None);
             assert_eq!(PSP34Enumerable::owners_token_by_index(&contract, accounts.bob, 0), Err(PSP34Error::TokenNotExists));
             assert_eq!(PSP34::balance_of(&contract, accounts.bob), 0);
         }
@@ -115,9 +143,9 @@ pub mod art_nft_psp34 {
             let mut contract = new_contract();
             let accounts = default_accounts();
             // Alice mints to Bob
-            let token_id = Id::U64(2);
-            let result = PSP34Mintable::mint(&mut contract, accounts.bob, token_id.clone());
-            assert_eq!(result, Ok(()));
+            let token_id = Id::U64(0);
+            let result = ArtNft::mint(&mut contract, vec![accounts.bob]);
+            assert_eq!(result, Ok(vec![(accounts.bob, token_id.clone())]));
             // Bob transfers to Charlie
             set_sender(accounts.bob);
             let result = PSP34::transfer(&mut contract, accounts.charlie, token_id.clone(), Vec::new());
@@ -134,9 +162,9 @@ pub mod art_nft_psp34 {
             let mut contract = new_contract();
             let accounts = default_accounts();
             // Alice mints to Bob
-            let token_id = Id::U64(2);
-            let result = PSP34Mintable::mint(&mut contract, accounts.bob, token_id.clone());
-            assert_eq!(result, Ok(()));
+            let token_id = Id::U64(0);
+            let result = ArtNft::mint(&mut contract, vec![accounts.bob]);
+            assert_eq!(result, Ok(vec![(accounts.bob, token_id.clone())]));
             // Charlie transfers to Charlie
             set_sender(accounts.charlie);
             let result = PSP34::transfer(&mut contract, accounts.charlie, token_id.clone(), Vec::new());
@@ -163,6 +191,5 @@ pub mod art_nft_psp34 {
         fn set_sender(sender: AccountId) {
             test::set_caller::<Environment>(sender);
         }
-
     }
 }


### PR DESCRIPTION
* It's now possible to mint NFT's to one or more accounts in one call.
* The `TokenId` is managed by the contract.
* An NFT with index `n` has always an id equal to `Id::U64(n)`, and vice-versa.
* The trait `psp34Mintable`, now useless, is removed.

logion-network/logion-internal#1033